### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/changeme/core.py
+++ b/changeme/core.py
@@ -20,7 +20,7 @@ PERSISTENT_QUEUE = "data.db" # Instantiated in the scan_engine class
 
 
 def banner(version):
-    b = """
+    b = r"""
  #####################################################
 #       _                                             #
 #   ___| |__   __ _ _ __   __ _  ___ _ __ ___   ___   #
@@ -158,7 +158,7 @@ class Config(object):
             ap.print_help()
             quit()
 
-        if self.proxy and re.match('^https?://[0-9\.]+:[0-9]{1,5}$', self.proxy):
+        if self.proxy and re.match(r'^https?://[0-9.]+:[0-9]{1,5}$', self.proxy):
             self.proxy = {'http': self.proxy, 'https': self.proxy}
             logger.info('Setting proxy to %s' % self.proxy)
         elif self.proxy:

--- a/changeme/scanners/telnet.py
+++ b/changeme/scanners/telnet.py
@@ -72,7 +72,7 @@ class Telnet(Scanner):
 
     @staticmethod
     def _trim_string(str_to_trim):
-        return str(str_to_trim).replace(' ','').replace('\s','').replace('\t','').replace('\r','').replace('\n','')
+        return re.sub(r'\s+', '', str(str_to_trim))
 
     def _mkscanner(self, cred, target, u, p, config):
         return Telnet(cred, target, u, p, config)


### PR DESCRIPTION
## Summary
- mark banner string as a raw literal to avoid escape sequence warnings
- validate proxy option using a raw regex
- simplify Telnet whitespace trimming using regex

## Testing
- `python -m py_compile changeme/core.py changeme/scanners/telnet.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a75887e3208323b728db109ac2be1a